### PR TITLE
Context and numeric sliders

### DIFF
--- a/generics_experiment/template/js/participant_questions.js
+++ b/generics_experiment/template/js/participant_questions.js
@@ -1,13 +1,18 @@
-var questions = [
+var questions = [    
+    {question: "Do you agree with the underlined statement?", dependent_measure: "binary"},
+    {question: "What percent of [plural noun] would you say [verb phrase]?", dependent_measure: "slider"},
+]
+
+var extra_questions = [
     {question: "Are [plural noun] inanimate?", dependent_measure: "binary"},
     {question: "How many [plural noun] would you say [verb phrase]?", dependent_measure: "slider"},
-    {question: "Can you empirically prove the veracity of the statement?", dependent_measure: "binary"},
-    {question: "Is this statement observable?", dependent_measure: "binary"},
+    {question: "Can you empirically prove the underlined statement?", dependent_measure: "binary"},
+    {question: "Is the underlined statement observable?", dependent_measure: "binary"},
     {question: "Are [plural noun] animals?", dependent_measure: "binary"},
     {question: "Around how many [plural noun] would you say there are?", dependent_measure: "textbox"},
     {question: "How many [plural noun] would you say [verb phrase]", dependent_measure: "slider"},
     {question: "Does [plural noun] pertain to a specific group of people? (lawyers, teachers, etc.)", dependent_measure: "binary"},
-    {question: "Is this statement debatable?", dependent_measure: "binary"},
+    {question: "Is the underlined statement debatable?", dependent_measure: "binary"},
 ]
 
 var random_questions = [];

--- a/generics_experiment/template/js/template.js
+++ b/generics_experiment/template/js/template.js
@@ -30,12 +30,18 @@ function make_slides(f) {
 	$(".err").hide();
 	$("#binary").hide();
 	$("#textbox").hide();
-	$("#likert").hide();
-	this.stim = stim;
+	$("#rate").hide();
+    this.stim = stim;
   var generics = generate_stim(number_of_generic_trials, true);
 	var generic = generics[Math.floor(Math.random() * generics.length)];
 	this.generic = generic;
-	$(".sentence").html("\"" + generic.Sentence + "\""); // Replace .Sentence with the name of your sentence column
+	var contexthtml = "... " + generic.Context;
+    contexthtml = contexthtml.replace(/###speakera(\d+)./g, "<br><b>Speaker #1:</b>");
+    contexthtml = contexthtml.replace(/###speakerb(\d+)./g, "<br><b>Speaker #2:</b>");
+    contexthtml = contexthtml.replace(/###/g, " ");
+    bare_plural = generic.Noun + " " + generic.VP
+    usentence = generic.Sentence.replace(bare_plural, "<u>" + bare_plural + "</u>");
+    $(".case").html(contexthtml + " " + usentence); // Replace .Sentence with the name of your sentence column
 	var question = stim.question.replace("[plural noun]", generic.Noun); // Replace .Noun with the name of your noun column
 	question = question.replace("[verb phrase]", generic.VP); // Replace .VP with the name of your verb column
 	$(".question").html(question);		
@@ -54,9 +60,11 @@ function make_slides(f) {
 		exp.responseValue = $(this).val();
 	    });
 	    break;
-	default:
-	    $("#likert").show();
-            this.init_sliders(); //TODO(chakia): what do we actually what on these sliders? What is the scale?
+    default:
+        $("#rate").show();
+        this.init_numeric_sliders();
+        exp.sliderPost = null;
+        break;
 	}
 	exp.responseValue = null;
     },
@@ -76,6 +84,18 @@ function make_slides(f) {
       utils.make_slider("#single_slider", function(event, ui) {
         exp.responseValue = ui.value;
       });
+    },
+
+    init_numeric_sliders : function() {
+        utils.make_slider("#single_slider", this.make_slider_callback());
+    },
+
+    make_slider_callback : function() {
+      return function(event, ui) {
+        exp.sliderPost = ui.value;
+        exp.responseValue = ui.value;
+        $(".slider_number").html(Math.round(exp.sliderPost*100) + "%");
+      };
     },
 
     log_responses : function() {

--- a/generics_experiment/template/js/template.js
+++ b/generics_experiment/template/js/template.js
@@ -35,11 +35,8 @@ function make_slides(f) {
   var generics = generate_stim(number_of_generic_trials, true);
 	var generic = generics[Math.floor(Math.random() * generics.length)];
 	this.generic = generic;
-	var contexthtml = "Read the following conversation snippet:<br><br>... " + generic.Context;
-    contexthtml = contexthtml.replace(/###speakera(\d+)./g, "<br><b>Speaker #1:</b>");
-    contexthtml = contexthtml.replace(/###speakerb(\d+)./g, "<br><b>Speaker #2:</b>");
-    contexthtml = contexthtml.replace(/###/g, " ");
-    bare_plural = generic.Noun + " " + generic.VP
+	var contexthtml = this.format_context(generic.Context);
+    bare_plural = generic.Noun + " " + generic.VP;
     usentence = generic.Sentence.replace(bare_plural, "<u>" + bare_plural + "</u>");
     $(".case").html(contexthtml + " " + usentence); // Replace .Sentence with the name of your sentence column
 	var question = stim.question.replace("[plural noun]", generic.Noun); // Replace .Noun with the name of your noun column
@@ -63,6 +60,7 @@ function make_slides(f) {
     default:
         $("#rate").show();
         this.init_numeric_sliders();
+        $(".slider_number").html("--");
         exp.sliderPost = null;
         break;
 	}
@@ -78,6 +76,26 @@ function make_slides(f) {
         "present" data. (and only *after* responses are logged) */
             _stream.apply(this);
 	}
+    },
+
+    format_context : function(context) {
+        contexthtml = context.replace(/###speakera(\d+)./g, "<br><b>Speaker #1:</b>");
+        contexthtml = contexthtml.replace(/###speakerb(\d+)./g, "<br><b>Speaker #2:</b>");
+        contexthtml = contexthtml.replace(/###/g, " ");
+        if (!contexthtml.startsWith("<br><b>Speaker #")) {
+            var ssi = contexthtml.indexOf("Speaker #");
+            switch(contexthtml[ssi+"Speaker #".length]) {
+            case "1":
+                contexthtml = "<br><b>Speaker #2:</b> " + contexthtml;
+                break;
+            case "2":
+                contexthtml = "<br><b>Speaker #1:</b> " + contexthtml;
+                break;
+            default:
+                break;
+            }
+        };
+        return contexthtml;
     },
 
     init_sliders : function() {

--- a/generics_experiment/template/js/template.js
+++ b/generics_experiment/template/js/template.js
@@ -35,7 +35,7 @@ function make_slides(f) {
   var generics = generate_stim(number_of_generic_trials, true);
 	var generic = generics[Math.floor(Math.random() * generics.length)];
 	this.generic = generic;
-	var contexthtml = "... " + generic.Context;
+	var contexthtml = "Read the following conversation snippet:<br><br>... " + generic.Context;
     contexthtml = contexthtml.replace(/###speakera(\d+)./g, "<br><b>Speaker #1:</b>");
     contexthtml = contexthtml.replace(/###speakerb(\d+)./g, "<br><b>Speaker #2:</b>");
     contexthtml = contexthtml.replace(/###/g, " ");

--- a/generics_experiment/template/template.html
+++ b/generics_experiment/template/template.html
@@ -59,18 +59,19 @@
   </div>
 
   <div class="slide" id="generic_trial_series">
-    <p class="sentence"></p>
+    <p class="case"></p>
     <p class="question"></p>
     <div id="textbox"><input type="text" id="textbox_response"></input></div>
     <div id="binary">
       <label><input type="radio"  name="binarychoice" value="No"/>No</label>
       <label><input type="radio"  name="binarychoice" value="Yes"/>Yes</label>
     </div>
-    <div id="likert">
-      <table id="slider_table" class="slider_table">
-	<tr><td class="left">None</td><td class="right">All</td></tr>
-	<tr><td colspan="2"><div id="single_slider" class="slider"></div></td></tr>
-      </table>
+    <div id="rate">
+        <p class="slider_number"></p>
+        <table id="slider_table" class="slider_table">
+            <tr><td class="left">0%</td><td class="right">100%</td></tr>
+            <tr><td colspan="2"><div id="single_slider" class="slider"></div></td></tr>
+        </table>
     </div>
     <br>
     <button onclick="_s.button()">Continue</button>

--- a/generics_experiment/template/template.html
+++ b/generics_experiment/template/template.html
@@ -59,7 +59,8 @@
   </div>
 
   <div class="slide" id="generic_trial_series">
-    <p class="case"></p>
+    <p>Read the following conversation snippet:</p>
+    <p class="case" style="text-align: left;"></p>
     <p class="question"></p>
     <div id="textbox"><input type="text" id="textbox_response"></input></div>
     <div id="binary">

--- a/generics_experiment/template/template.html
+++ b/generics_experiment/template/template.html
@@ -54,7 +54,7 @@
 
   <div class="slide" id="instructions">
     <h3>Instructions</h3>
-    <p>Please answer the following questions based off of the given sentence.</p>
+    <p>Please read the following passages and answer the questions regarding the underlined phrase.</p>
     <button onclick="_s.button()">Continue</button>
   </div>
 


### PR DESCRIPTION
The code should now add well-formatted prior context, with underlining to indicate the utterance in question. Also, it just uses the prevalence and agreement/disagreement questions, with a percentage slider for the former. On your end, you might need a few small modifications: mine is formatted to work with columns titled Noun, VP, Sentence, and Context.